### PR TITLE
mark-devkit: Bump dev-util/pkgs-checker-0.16.0-r1

### DIFF
--- a/dev-util/pkgs-checker/pkgs-checker-0.16.0-r1.ebuild
+++ b/dev-util/pkgs-checker/pkgs-checker-0.16.0-r1.ebuild
@@ -31,6 +31,9 @@ src_compile() {
 src_install() {
 	dobin "${PN}"
 	dodoc README.md
+	insinto /usr/share/pkgs-checker
+	doins "${S}"/contrib/gen-uses-filter.yaml
+	
 }
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package dev-util/pkgs-checker-0.16.0-r1 for branch mark-unstable by mark-bot