### PR TITLE
mark-devkit: [mark-unstable] Bump dev-util/anise-repo-devkit-0.1.1-r1

### DIFF
--- a/dev-util/anise-repo-devkit/anise-repo-devkit-0.1.1-r1.ebuild
+++ b/dev-util/anise-repo-devkit/anise-repo-devkit-0.1.1-r1.ebuild
@@ -1,6 +1,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+inherit go-module
 
 DESCRIPTION="Anise Repository Development Kit Knife"
 HOMEPAGE="https://github.com/macaroni-os/anise-repo-devkit"


### PR DESCRIPTION
Automatic bump of package dev-util/anise-repo-devkit-0.1.1-r1 for branch mark-unstable by mark-bot